### PR TITLE
Add support for top_level_only in groups listing

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -87,6 +87,7 @@ type ListGroupsOptions struct {
 	SkipGroups           []int             `url:"skip_groups,omitempty" json:"skip_groups,omitempty"`
 	Sort                 *string           `url:"sort,omitempty" json:"sort,omitempty"`
 	Statistics           *bool             `url:"statistics,omitempty" json:"statistics,omitempty"`
+	TopLevelOnly         *bool             `url:"top_level_only,omitempty" json:"top_level_only,omitempty"`
 	WithCustomAttributes *bool             `url:"with_custom_attributes,omitempty" json:"with_custom_attributes,omitempty"`
 }
 


### PR DESCRIPTION
There is a new optional available when listing groups: top_level_only --> Limit to top level groups, excluding all subgroups

See https://docs.gitlab.com/ee/api/groups.html#list-groups

The change is untested but from my POV should work out of the box. Please review.